### PR TITLE
PR2: Add CI/CD pipeline with GitHub Actions

### DIFF
--- a/HW2-Infrastructure-setup/.github/workflows/ci-cd.yml
+++ b/HW2-Infrastructure-setup/.github/workflows/ci-cd.yml
@@ -1,0 +1,28 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: ./HW2-Infrastructure-setup
+        push: true
+        tags: msasmsasmsas/fastapi-server:latest


### PR DESCRIPTION
Додано CI/CD-пайплайн для автоматичної побудови та публікації Docker-образу.
- Створено `.github/workflows/ci-cd.yml`.
- Налаштовано секрети для Docker Hub.
- Пайплайн запускається для push і pull request у гілку main.